### PR TITLE
Information note about outdated article

### DIFF
--- a/content.php
+++ b/content.php
@@ -35,6 +35,16 @@
 	</h4>
 
 	<div class="entry-content">
+		<?php if ( is_single() && date('Y-m-d', strtotime('-1 year')) > get_the_modified_date('Y-m-d') ) : ?>
+			<blockquote>
+				<p>
+					It's been over a year since this article was last updated.
+					The information below might be outdated.
+					Please contact the author for more.
+				</p>
+			</blockquote>
+		<?php endif; ?>
+
 		<?php
 			/* translators: %s: Name of current post */
 			the_content( sprintf(

--- a/readme.txt
+++ b/readme.txt
@@ -11,6 +11,13 @@ Tags: blog, two-columns, left-sidebar, accessibility-ready, custom-background, c
 A WordPress theme based in the TwentyFifteen
 
 == Changelog ==
+= 1.6.3 = Dec, 13, 2019
+* Removing Google Plus share button
+* CSS class for images that cannot be zoomed
+* Support SSL secure connections via HTTPS
+* Bringing back Linkedin share button
+* Information note about outdated article
+
 = 1.6.2 = Sep, 1, 2017
 * Search result nothing found: Search box issue fixed
 


### PR DESCRIPTION
From now on, users will be aware of outdated articles, as opening any article link will have a message stating that the article is out of date if it has been more than a year since its last update.